### PR TITLE
Implement block lookup helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "toml",

--- a/aura-node-lib/Cargo.toml
+++ b/aura-node-lib/Cargo.toml
@@ -57,3 +57,6 @@ sha3 = "0.10"
 [features]
 default = []
 # rpc-server = ["dep:jsonrpsee"] # Example feature for enabling RPC
+
+[dev-dependencies]
+tempfile = "3"

--- a/aura-node-lib/tests/state_tests.rs
+++ b/aura-node-lib/tests/state_tests.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+use tempfile::tempdir;
+
+use aura_node_lib::state::AuraState;
+use aura_core::{PrivateKey, Transaction, ZkProofData, Fee, Memo};
+
+fn dummy_tx() -> Transaction {
+    Transaction {
+        spent_nullifiers: Vec::new(),
+        new_note_commitments: Vec::new(),
+        zk_proof_data: ZkProofData { proof_bytes: Vec::new() },
+        fee: Fee(0),
+        anchor: [0u8; 32],
+        memo: Memo(Vec::new()),
+    }
+}
+
+#[test]
+fn test_min_height_and_get_block() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("db.redb");
+    let pk = PrivateKey::new_random();
+    let mut state = AuraState::new(&db_path, Arc::new(pk)).unwrap();
+
+    state.begin_block(1, vec![1u8], 1).unwrap();
+    state.deliver_tx(dummy_tx()).unwrap();
+    state.end_block(1).unwrap();
+    state.commit_block().unwrap();
+
+    assert_eq!(state.min_height().unwrap(), 1);
+    let block = state.get_block(1).unwrap();
+    assert_eq!(block.height, 1);
+    assert_eq!(block.transactions.len(), 1);
+
+    // reopen state and ensure persistence
+    drop(state);
+    let pk2 = PrivateKey::new_random();
+    let state2 = AuraState::new(&db_path, Arc::new(pk2)).unwrap();
+    assert_eq!(state2.min_height().unwrap(), 1);
+    let block2 = state2.get_block(1).unwrap();
+    assert_eq!(block2.transactions.len(), 1);
+}


### PR DESCRIPTION
## Summary
- add `min_height` and `get_block` helpers for `AuraState`
- reply with actual values in `GetHistoryMinHeight` and `GetDecidedValue`
- unit test block retrieval from the database
- add `tempfile` dev-dependency
- remove unused import in tests

## Testing
- `cargo clippy --workspace --tests -- -D warnings` *(fails: attempting to download dependencies offline)*
- `cargo test -p aura-node-lib --tests` *(fails: attempting to download dependencies offline)*