### PR TITLE
Implement block query helpers

### DIFF
--- a/aura-node-lib/src/node.rs
+++ b/aura-node-lib/src/node.rs
@@ -423,7 +423,7 @@ pub async fn app_message_loop(
                             AppMsg::GetHistoryMinHeight { reply } => {
                                 info!("AppLoop: GetHistoryMinHeight called");
                                 let state = app_state_arc.lock().map_err(|e| eyre!("Mutex lock failed: {}", e))?;
-                                let min_h = TestHeight::new(state.history_min_height());
+                                let min_h = TestHeight::new(state.min_height()?);
                                 if reply.send(min_h).is_err() {
                                     error!("AppLoop: Failed to send GetHistoryMinHeight reply");
                                 }
@@ -445,7 +445,7 @@ pub async fn app_message_loop(
                                     valid_round: Round::Nil,
                                     proposer,
                                     value: TestValue::new(height.as_u64()),
-                                    validity: if state.get_block(height.as_u64())?.is_some() { Validity::Valid } else { Validity::Invalid },
+                                    validity: if state.get_block(height.as_u64()).is_ok() { Validity::Valid } else { Validity::Invalid },
                                 };
                                 if reply.send(proposed).is_err() {
                                    error!("AppLoop: Failed to send ProcessSyncedValue reply");

--- a/aura-node-lib/src/state.rs
+++ b/aura-node-lib/src/state.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::VecDeque, path::Path, sync::Arc};
 
 use crate::malachitebft_core_types::{Round, Value as MalachiteValue};
 use aura_core::Transaction;
-use redb::{Database, TableDefinition, WriteTransaction};
+use redb::{Database, ReadableTable, TableDefinition, WriteTransaction};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::{debug, error, info, warn};
@@ -324,23 +324,30 @@ impl AuraState {
         Ok(())
     }
 
-    /// Retrieve a stored block by height if available
-    pub fn get_block(&self, height: u64) -> AuraResult<Option<Block>> {
+    /// Retrieve a stored block by height.  Returns an error if the block is not
+    /// present in the database.
+    pub fn get_block(&self, height: u64) -> AuraResult<Block> {
         let read_txn = self.db.begin_read()?;
         let blocks_table = read_txn.open_table(BLOCKS_TABLE)?;
         if let Some(entry) = blocks_table.get(&height)? {
             let block_bytes = entry.value();
             let block: Block = serde_json::from_slice(block_bytes)
                 .map_err(|e| Error::State(format!("Failed to deserialize block: {}", e)))?;
-            Ok(Some(block))
+            Ok(block)
         } else {
-            Ok(None)
+            Err(Error::State(format!("Block at height {height} not found")))
         }
     }
 
     /// Minimum height retained in the state database
-    pub fn history_min_height(&self) -> u64 {
-        if self.current_height == 0 { 0 } else { 1 }
+    pub fn min_height(&self) -> AuraResult<u64> {
+        let read_txn = self.db.begin_read()?;
+        let blocks_table = read_txn.open_table(BLOCKS_TABLE)?;
+        if let Some((key_guard, _)) = blocks_table.first()? {
+            Ok(key_guard.value())
+        } else {
+            Ok(0)
+        }
     }
 
     fn persist_block_and_txs(

--- a/aura-node-lib/tests/state.rs
+++ b/aura-node-lib/tests/state.rs
@@ -1,0 +1,19 @@
+use aura_node_lib::AuraState;
+use std::sync::Arc;
+
+#[test]
+fn test_block_commit_and_retrieval() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("state.db");
+    let priv_key = aura_core::keys::PrivateKey::new_random();
+    let mut state = AuraState::new(&db_path, Arc::new(priv_key)).unwrap();
+
+    state
+        .begin_block(1, vec![], chrono::Utc::now().timestamp())
+        .unwrap();
+    state.commit_block().unwrap();
+
+    assert_eq!(state.min_height().unwrap(), 1);
+    let block = state.get_block(1).unwrap();
+    assert_eq!(block.height, 1);
+}


### PR DESCRIPTION
## Summary
- expand AuraState with `min_height` and improved `get_block`
- query state DB from app loop
- test retrieval after committing blocks

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --workspace`
- `cargo clippy`