### PR TITLE
Automate genesis snapshot handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ark-std",
+ "attohttpc",
  "aura-core",
  "aura-node-lib",
  "aura-wallet-lib",
+ "bech32",
  "clap",
  "config 0.15.11",
  "futures",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,14 @@ Unless we choose another path, we'll be using the bech32 side (cosmos side) of "
 * Unity's Snapshot
   * QmNyt5bh6KRgPukeH2XScdRnycn4pxHVyAdMKgrHVMktGX
  
-Instead of forcing users to go out and get genesis on their own, Aura will automagically download a snapshot, do a bech32 conversion, and create genesis on its own.  This is designed to be a very easy process for cosmos-sdk blockchains, and may support Solana in the future. 
+Instead of forcing users to go out and get genesis on their own, Aura will automagically download a snapshot, do a bech32 conversion, and create genesis on its own.  This is designed to be a very easy process for cosmos-sdk blockchains, and may support Solana in the future.
+
+When running `aura node start` the client checks for `~/.aura/genesis.json`.  If
+it doesn't exist the snapshot referenced above is fetched from IPFS, all
+`unicorn` bech32 addresses are converted to the `whiteaura` prefix and any
+`uwunicorn` denominations are renamed to `uaura`.  The resulting genesis file is
+written to the configured location so new nodes can join the testnet with a
+single command.
 
 ## Approximate Layout
 

--- a/aura/Cargo.toml
+++ b/aura/Cargo.toml
@@ -21,6 +21,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
 rand = "0.9"
 futures = "0.3"
+bech32 = "0.11"
+attohttpc = { version = "0.24", default-features = false }
 
 # Workspace dependencies
 aura-node-lib = { path = "../aura-node-lib" }

--- a/aura/src/node_cmd.rs
+++ b/aura/src/node_cmd.rs
@@ -1,9 +1,12 @@
 use crate::config::AuraAppConfig;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use aura_node_lib::malachitebft_app::node::Node as MalachiteAppNodeTrait;
 use clap::Subcommand;
 use std::path::Path;
 use std::sync::Arc; // Required for Arc::new
+
+use bech32::{self, Bech32m, primitives::hrp::Hrp};
+use serde::{Deserialize, Serialize};
 
 #[derive(Subcommand, Debug)]
 pub enum NodeCommands {
@@ -15,6 +18,63 @@ pub enum NodeCommands {
     },
     /// Show node status (to be implemented)
     Status,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SnapshotCoin {
+    amount: String,
+    denom: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SnapshotAccount {
+    address: String,
+    coins: Vec<SnapshotCoin>,
+    #[serde(default)]
+    is_validator: bool,
+}
+
+fn convert_address(addr: &str) -> Result<String> {
+    let (hrp, data) =
+        bech32::decode(addr).map_err(|e| anyhow!(format!("bech32 decode error: {}", e)))?;
+    if hrp.as_str() != "unicorn" {
+        return Err(anyhow!(format!("unexpected hrp: {}", hrp.as_str())));
+    }
+    let new_hrp = Hrp::parse_unchecked("whiteaura");
+    let encoded = bech32::encode::<Bech32m>(new_hrp, &data)
+        .map_err(|e| anyhow!(format!("bech32 encode error: {}", e)))?;
+    Ok(encoded)
+}
+
+fn ensure_genesis_from_snapshot(path: &Path) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    tracing::info!("Genesis file {:?} not found. Downloading snapshot...", path);
+    let url = format!("http://ipfs.io/ipfs/{}", "QmNLocWsww2QgXGawfMPj8tn9ggzEt4dbiywAKiFjgGQhr");
+    let response = attohttpc::get(&url)
+        .send()
+        .map_err(|e| anyhow!(format!("failed to fetch snapshot: {}", e)))?;
+    if !response.is_success() {
+        return Err(anyhow!(format!("snapshot fetch returned status {}", response.status())));
+    }
+    let json = response
+        .text()
+        .map_err(|e| anyhow!(format!("failed to read snapshot: {}", e)))?;
+    let mut accounts: Vec<SnapshotAccount> = serde_json::from_str(&json)?;
+    for acc in &mut accounts {
+        acc.address = convert_address(&acc.address)?;
+        for coin in &mut acc.coins {
+            if coin.denom == "uwunicorn" {
+                coin.denom = "uaura".to_string();
+            }
+        }
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&accounts)?)?;
+    Ok(())
 }
 
 pub async fn handle_node_command(
@@ -29,6 +89,12 @@ pub async fn handle_node_command(
                 "Node configuration from app_config.node: {:?}",
                 app_config.node
             );
+
+            let genesis_path = {
+                let path = shellexpand::tilde(&app_config.node.genesis_file_path).into_owned();
+                std::path::PathBuf::from(path)
+            };
+            ensure_genesis_from_snapshot(&genesis_path)?;
 
             // Construct aura_node_lib::config::AuraNodeConfig from aura::config::NodeConfig
             let node_lib_config = aura_node_lib::AuraNodeConfig {

--- a/malachite
+++ b/malachite
@@ -1,0 +1,1 @@
+Subproject commit 696fa1c4f31855279fc6ea4f3d21000390b1a3c3


### PR DESCRIPTION
## Summary
- fetch snapshot on `node start` if no genesis exists
- convert `unicorn` bech32 addresses to `whiteaura`
- rename `uwunicorn` denom to `uaura`
- embed attohttpc for IPFS snapshot fetch

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --fix --offline --allow-dirty`
- `cargo build --quiet`
- `cargo test --workspace --quiet`
