### PR TITLE
Enable real zero-knowledge proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,9 @@ dependencies = [
 name = "aura-wallet-lib"
 version = "0.1.0"
 dependencies = [
+ "ark-crypto-primitives",
  "ark-ff",
+ "ark-serialize",
  "ark-std",
  "aura-core",
  "rand 0.9.1",

--- a/aura-core/Cargo.toml
+++ b/aura-core/Cargo.toml
@@ -68,7 +68,7 @@ ark-std = { version = "0.5.0", default-features = false, features = [
 tracing = { version = "0.1", optional = true }
 
 [features]
-default = ["std", "mock-zkp"]
+default = ["std"]
 std = [
     "ark-ff/std",
     "ark-ec/std",
@@ -81,6 +81,5 @@ std = [
     "ark-std/std",
     "dep:tracing",               # Enable tracing when std is enabled
 ]
-mock-zkp = []
 parallel = ["ark-std/parallel"]
 tracing = ["dep:tracing"] # Add explicit tracing feature

--- a/aura-core/src/keys.rs
+++ b/aura-core/src/keys.rs
@@ -3,7 +3,7 @@ use crate::{AURA_ADDR_HRP, AuraAddress, CurveFr, CurveG1};
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{BigInteger as ArkBigInteger, PrimeField, UniformRand};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::rand::{RngCore, SeedableRng, rngs::StdRng};
+use ark_std::rand::{SeedableRng, rngs::StdRng};
 use bip39::{Language, Mnemonic};
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;

--- a/aura-core/src/lib.rs
+++ b/aura-core/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "mock-zkp", allow(unused_variables, unused_imports))]
-
 pub mod address;
 pub mod crypto;
 pub mod error;

--- a/aura-core/src/zkp.rs
+++ b/aura-core/src/zkp.rs
@@ -2,11 +2,7 @@ use crate::note::poseidon_config;
 use crate::transaction::ZkProofData;
 use crate::{AuraCurve, CoreError, CurveFr};
 use ark_crypto_primitives::sponge::constraints::CryptographicSpongeVar;
-use ark_crypto_primitives::sponge::{
-    CryptographicSponge, FieldBasedCryptographicSponge,
-    poseidon::{PoseidonSponge, constraints::PoseidonSpongeVar},
-};
-use ark_ff::PrimeField;
+use ark_crypto_primitives::sponge::poseidon::constraints::PoseidonSpongeVar;
 use ark_ff::Zero;
 use ark_groth16::{
     Groth16, PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey, prepare_verifying_key,
@@ -18,7 +14,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
 use ark_std::io::BufReader;
-use ark_std::rand::{RngCore, SeedableRng, rngs::StdRng};
+use ark_std::rand::{SeedableRng, rngs::StdRng};
 use ark_std::vec::Vec;
 use std::fs::File;
 use std::path::Path;
@@ -71,7 +67,7 @@ impl ConstraintSynthesizer<CurveFr> for TransferCircuit {
                 .map(CurveFr::from)
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
-        let input_owner = FpVar::<CurveFr>::new_witness(cs.clone(), || {
+        let _input_owner = FpVar::<CurveFr>::new_witness(cs.clone(), || {
             self.input_note_owner_pk_hash
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;

--- a/aura-wallet-lib/Cargo.toml
+++ b/aura-wallet-lib/Cargo.toml
@@ -8,3 +8,5 @@ aura-core = { path = "../aura-core" }
 rand = "0.9"
 ark-ff = "0.5"
 ark-std = "0.5.0"
+ark-crypto-primitives = "0.5.0"
+ark-serialize = "0.5.0"

--- a/aura-wallet-lib/src/lib.rs
+++ b/aura-wallet-lib/src/lib.rs
@@ -2,12 +2,16 @@
 //!
 //! This library provides wallet functionality for the Aura blockchain.
 
-use ark_ff::UniformRand;
-use ark_std::rand::{SeedableRng, rngs::StdRng};
+use ark_crypto_primitives::sponge::{
+    CryptographicSponge, FieldBasedCryptographicSponge, poseidon::PoseidonSponge,
+};
+use ark_ff::{PrimeField, UniformRand};
+use ark_std::rand::{rngs::StdRng, SeedableRng};
+use ark_serialize::CanonicalSerialize;
 use aura_core::keys::{generate_keypair_from_seed_phrase_str, generate_new_keypair_and_seed};
 use aura_core::{
     CurveFr, Fee, Memo, Note, Nullifier, PrivateKey, PublicKey, SeedPhrase, Transaction,
-    ZkProofData,
+    ZkpHandler, ZkpParameters, poseidon_config,
 };
 
 /// Represents an in-memory wallet keypair with optional seed phrase.
@@ -59,6 +63,7 @@ impl Wallet {
         recipient: &aura_core::AuraAddress,
         amount: u64,
         fee: u64,
+        params: &ZkpParameters,
     ) -> Result<(Transaction, Note), aura_core::CoreError> {
         if amount + fee > input_note.value {
             return Err(aura_core::CoreError::InsufficientFunds);
@@ -69,6 +74,7 @@ impl Wallet {
         let mut rng = StdRng::from_entropy();
         let out_randomness = CurveFr::rand(&mut rng);
         let change_randomness = CurveFr::rand(&mut rng);
+        let anchor = CurveFr::rand(&mut rng);
 
         let output_note = Note::new(amount, recipient, out_randomness);
         let change_note = Note::new(change_value, &self.address, change_randomness);
@@ -79,14 +85,75 @@ impl Wallet {
         let nullifier =
             Nullifier::new_outside_circuit(&input_note.randomness, &self.private_key.0)?;
 
+        // Helper hashes for circuit
+        let mut sponge = PoseidonSponge::new(&poseidon_config());
+        sponge.absorb(&input_note.randomness);
+        sponge.absorb(&self.private_key.0);
+        let expected_nullifier = sponge.squeeze_native_field_elements(1)[0];
+
+        let mut sponge1 = PoseidonSponge::new(&poseidon_config());
+        sponge1.absorb(&CurveFr::from(amount));
+        sponge1.absorb(&CurveFr::from_le_bytes_mod_order(recipient.payload()));
+        sponge1.absorb(&out_randomness);
+        let expected_out_commit = sponge1.squeeze_native_field_elements(1)[0];
+
+        let mut sponge2 = PoseidonSponge::new(&poseidon_config());
+        sponge2.absorb(&CurveFr::from(change_value));
+        sponge2.absorb(&CurveFr::from_le_bytes_mod_order(self.address.payload()));
+        sponge2.absorb(&change_randomness);
+        let expected_change_commit = sponge2.squeeze_native_field_elements(1)[0];
+
+        let circuit = aura_core::TransferCircuit {
+            input_note_value: Some(input_note.value),
+            input_note_owner_pk_hash: Some(CurveFr::from_le_bytes_mod_order(
+                &input_note.owner_pk_info,
+            )),
+            input_note_randomness: Some(input_note.randomness),
+            input_spending_key_scalar: Some(self.private_key.0),
+            output1_note_value: Some(amount),
+            output1_note_owner_pk_hash: Some(CurveFr::from_le_bytes_mod_order(recipient.payload())),
+            output1_note_randomness: Some(out_randomness),
+            output2_note_value: Some(change_value),
+            output2_note_owner_pk_hash: Some(CurveFr::from_le_bytes_mod_order(
+                self.address.payload(),
+            )),
+            output2_note_randomness: Some(change_randomness),
+            anchor: Some(anchor),
+            fee: Some(fee),
+            expected_nullifier: Some(expected_nullifier),
+            expected_output1_commitment: Some(expected_out_commit),
+            expected_output2_commitment: Some(expected_change_commit),
+        };
+
+        let proof = ZkpHandler::generate_proof(&params.proving_key, circuit)?;
+        let public_inputs = ZkpHandler::prepare_public_inputs_for_verification(
+            anchor,
+            fee,
+            expected_nullifier,
+            expected_out_commit,
+            expected_change_commit,
+        );
+        if !ZkpHandler::verify_proof(&params.prepared_verifying_key, &public_inputs, &proof)? {
+            return Err(aura_core::CoreError::ProofVerification(
+                "self-verification failed".to_string(),
+            ));
+        }
+
+        let mut anchor_bytes = Vec::new();
+        anchor
+            .serialize_compressed(&mut anchor_bytes)
+            .map_err(|e| aura_core::CoreError::Serialization(e.to_string()))?;
+        let anchor_arr: [u8; 32] = anchor_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| aura_core::CoreError::Serialization("Invalid length".to_string()))?;
+
         let tx = Transaction {
             spent_nullifiers: vec![nullifier],
             new_note_commitments: vec![output_commit, change_commit],
-            zk_proof_data: ZkProofData {
-                proof_bytes: Vec::new(),
-            },
+            zk_proof_data: proof,
             fee: Fee(fee),
-            anchor: [0u8; 32],
+            anchor: anchor_arr,
             memo: Memo(Vec::new()),
         };
 

--- a/malachite
+++ b/malachite
@@ -1,0 +1,1 @@
+Subproject commit 696fa1c4f31855279fc6ea4f3d21000390b1a3c3


### PR DESCRIPTION
## Summary
- drop `mock-zkp` feature from aura-core
- implement Poseidon based nullifier creation
- generate Groth16 proofs when building wallet transfers
- verify generated proofs and store anchors
- add needed dependencies
- fix unused imports and variables in the ZKP module

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --workspace`
- `cargo clippy --fix --offline`
